### PR TITLE
fix(windows): add runInShell support for Process.start on Windows

### DIFF
--- a/lib/src/core/test_runner.dart
+++ b/lib/src/core/test_runner.dart
@@ -31,7 +31,7 @@ class TestRunner {
     final stopwatch = Stopwatch();
     stopwatch.start();
     var future = await Process.start(cmd.command, cmd.arguments,
-        workingDirectory: cmd.directory);
+        workingDirectory: cmd.directory, runInShell: Platform.isWindows);
     _pid = future.pid;
     _started = true;
     var stdout = '';


### PR DESCRIPTION
Related issue: https://github.com/domohuhn/mutation-test/issues/29

## Description
Fixes ProcessException on Windows when running mutation tests by adding `runInShell` parameter to `Process.start()`.

## Problem
On Windows, the mutation test fails with: ProcessException: The system cannot find the file specified.

This occurs because Windows cannot resolve PATH executables like `flutter` without shell context.

## Solution
Added conditional `runInShell: Platform.isWindows` to the `Process.start()` call in `test_runner.dart`. This enables shell execution only on Windows while maintaining default behavior on other platforms.

## Changes
- Modified `lib/src/core/test_runner.dart`:
  - Added `runInShell: Platform.isWindows` parameter to `Process.start()`

## Testing
- ✅ Tested on Windows 10 with Flutter 3.35.3
- ✅ Mutation tests now run successfully on Windows
- ✅ No impact on Linux/macOS (runInShell defaults to false)